### PR TITLE
Add total addresses info in confirm section

### DIFF
--- a/frontend/src/components/Confirm.tsx
+++ b/frontend/src/components/Confirm.tsx
@@ -63,7 +63,7 @@ const Confirm = ({
                     ))}
                 <li>
                     <div className="flex justify-between mt-4 border-t border-black">
-                        <div className="italic">total</div>
+                        <div className="italic">total ({recipientsData.length} addresses)</div>
                         <div className="italic">
                             {total ? ethers.utils.formatUnits(total, tokenDecimals ?? 18) : ""} {tokenSymbol}
                         </div>

--- a/frontend/src/components/ConfirmEther.tsx
+++ b/frontend/src/components/ConfirmEther.tsx
@@ -46,7 +46,7 @@ const ConfirmEther = ({ recipientsData, total, tokenBalance, remaining, disperse
                     ))}
                 <li>
                     <div className="flex justify-between mt-4 border-t border-black">
-                        <div className="italic">total</div>
+                        <div className="italic">total ({recipientsData.length} addresses)</div>
                         <div className="italic">{total ? ethers.utils.formatEther(total) : ""} CAM</div>
                     </div>
                 </li>


### PR DESCRIPTION
Adds total addresses info in the confirm section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the total amount display in the Confirm and ConfirmEther components to include the number of recipient addresses for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->